### PR TITLE
Update proposals and webhooks documentation to include initial_proposal_id field for change order proposals

### DIFF
--- a/source/includes/_proposals.md
+++ b/source/includes/_proposals.md
@@ -57,7 +57,8 @@ curl "https://api.arcsite.com/v1/proposals" \
     "approved_option": {
       "id": "789",
       "drawing_id": "abc123def456"
-    }
+    },
+    "initial_proposal_id": "111"
   }
 ]
 ```
@@ -95,6 +96,7 @@ Each item in the response array is a `Proposal` object with the following fields
 | total                | Number         | (optional) Total amount of the proposal. Present when status is `APPROVED`.          |
 | pdf_url              | String         | (optional) URL of the proposal PDF file. Present when status is `APPROVED`.          |
 | approved_option      | ApprovedOption | (optional) Approved option information. Present when status is `APPROVED`.           |
+| initial_proposal_id  | String         | (optional) ID of the initial proposal. Only present for change order proposals.      |
 
 ### ApprovedOption
 

--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -283,15 +283,16 @@ The returned <code>url</code> in proposal options will expire in 24 hours. It's 
 
 ### Proposal Approved Webhook Payload
 
-| Parameter            | Type           | Description                          |
-| -------------------- | -------------- | ------------------------------------ |
-| project_id           | id             | Approved proposal related project ID |
-| proposal_id          | id             | Proposal ID                          |
-| name                 | String         | Proposal name                        |
-| customer_name        | String         | Proposal customer name               |
-| contact_email        | String         | The sales email                      |
-| sales_representative | String         | The sales name                       |
-| approved_option      | ProposalOption | Approved proposal option data        |
+| Parameter            | Type           | Description                                                                     |
+| -------------------- | -------------- | ------------------------------------------------------------------------------- |
+| project_id           | id             | Approved proposal related project ID                                            |
+| proposal_id          | id             | Proposal ID                                                                     |
+| name                 | String         | Proposal name                                                                   |
+| customer_name        | String         | Proposal customer name                                                          |
+| contact_email        | String         | The sales email                                                                 |
+| sales_representative | String         | The sales name                                                                  |
+| approved_option      | ProposalOption | Approved proposal option data                                                   |
+| initial_proposal_id  | String         | (optional) ID of the initial proposal. Only present for change order proposals. |
 
 ## Proposal Status Changed
 
@@ -314,6 +315,7 @@ The returned <code>url</code> in proposal options will expire in 24 hours. It's 
 | total                | Number | (optional)The total of the proposal (Only present when status is APPROVED)                                                                           |
 | pdf_url              | String | (optional) Download link to the proposal PDF file. Only present when status is APPROVED. Contains the signed version if the proposal has been signed |
 | approved_option      | Object | (optional) Contains `drawing_id` (String) field and `id` (String) field only for online approvals. Only present when status is APPROVED              |
+| initial_proposal_id  | String | (optional) ID of the initial proposal. Only present for change order proposals.                                                                      |
 
 <aside class="notice">
 The status field is an enum with the following values:

--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -292,7 +292,6 @@ The returned <code>url</code> in proposal options will expire in 24 hours. It's 
 | contact_email        | String         | The sales email                                                                 |
 | sales_representative | String         | The sales name                                                                  |
 | approved_option      | ProposalOption | Approved proposal option data                                                   |
-| initial_proposal_id  | String         | (optional) ID of the initial proposal. Only present for change order proposals. |
 
 ## Proposal Status Changed
 


### PR DESCRIPTION
添加 initial_proposal_id for Change Orders