### PR TITLE
docs(line_items): add description and price_part_name fields

### DIFF
--- a/source/includes/_product_items.md
+++ b/source/includes/_product_items.md
@@ -30,16 +30,29 @@ curl "https://api.arcsite.com/v1/drawings/<ID>/line_items" \
   "line_items": [
     {
       "name": "product1",
+      "description": "Product 1 description",
       "quantity": 2.26,
       "total": 0,
       "product_id": "19923123", // not exist for custom price items
       "sku": "sku1", //  not exist for custom price items
       "price": 3.5, //   not exist for custom price items
       "cost": 5,
-      "unit": "FT" //   not exist for custom price items
+      "unit": "FT", //   not exist for custom price items
+      "price_part_items": [
+        {
+          "name": "Option A",
+          "price_part_name": "Material",
+          "sku": "MAT-001",
+          "price": 10,
+          "cost": 5,
+          "quantity": 2,
+          "unit": "EA"
+        }
+      ]
     },
     {
       "name": "product2",
+      "description": "Custom item description",
       "quantity": 32.57,
       "total": 128.98,
       "cost": 200
@@ -95,28 +108,30 @@ If the <code>drawing_version_id</code> is passed, the drawing line items data of
 
 ### LineItem
 
-| Name             | Type                 | Description                                                                             |
-| ---------------- | -------------------- | --------------------------------------------------------------------------------------- |
-| name             | String               | The name of the product                                                                 |
-| quantity         | Number               | The quantity of the product                                                             |
-| total            | Number               | Item total after discounts and markup applied                                           |
-| price            | Number?              | Item total before discounts and markup applied; not provided for custom price items     |
-| cost             | Number?              | Item cost                                                                               |
-| sku              | String?              | The stock keeping unit of the product; not provided for custom price items              |
-| unit             | String?              | The unit of measurement for the product's quantity; not provided for custom price items |
-| product_id       | String?              | The ID of the product; not provided for custom price items                              |
-| price_part_items | List[PricePartItem]? | Detail of price part items; not provided for custom price items                         |
+| Name             | Type                 | Description                                                                                            |
+| ---------------- | -------------------- | ------------------------------------------------------------------------------------------------------ |
+| name             | String               | The name of the product                                                                                |
+| description      | String?              | The description of the product (or of the custom price item)                                           |
+| quantity         | Number               | The quantity of the product                                                                            |
+| total            | Number               | Item total after discounts and markup applied                                                          |
+| price            | Number?              | Item total before discounts and markup applied; not provided for custom price items                    |
+| cost             | Number?              | Item cost                                                                                              |
+| sku              | String?              | The stock keeping unit of the product; not provided for custom price items                             |
+| unit             | String?              | The unit of measurement for the product's quantity; not provided for custom price items                |
+| product_id       | String?              | The ID of the product; not provided for custom price items                                             |
+| price_part_items | List[PricePartItem]? | Detail of price part items; not provided for custom price items                                        |
 
 ### PricePartItem
 
-| Name     | Type   | Description                             |
-| -------- | ------ | --------------------------------------- |
-| name     | String | The name of price part option           |
-| sku      | String | The sku of price part option            |
-| price    | Number | The total price of price part option    |
-| cost     | Number | The total cost of price part option     |
-| quantity | Number | The total quantity of price part option |
-| unit     | String | The final unit of price part option     |
+| Name            | Type   | Description                             |
+| --------------- | ------ | --------------------------------------- |
+| name            | String | The name of price part option           |
+| price_part_name | String | The name of the price part              |
+| sku             | String | The sku of price part option            |
+| price           | Number | The total price of price part option    |
+| cost            | Number | The total cost of price part option     |
+| quantity        | Number | The total quantity of price part option |
+| unit            | String | The final unit of price part option     |
 
 ### TaxItem
 


### PR DESCRIPTION
## Summary

- Document two new fields exposed by `GET /v1/drawings/<id>/line_items` (and `/excluded_line_items`):
  - `description` on every line item — sourced from the product description for product items, and from the custom item description for custom price items.
  - `price_part_name` on every entry in `price_part_items`, alongside the existing `name` (price option name).
- Motivation (ARC-3466): a customer is rebuilding QuickBooks Online estimates/invoices from our OpenAPI because the existing QBO integration does not support progress invoicing. They need line-item parity with the in-app proposal to do so.

## Notes

- Backend change in `cloudservice` (`arcservice/services/open_api.py` → `serialize_price_result`) lands in a separate PR. **Merge this docs PR only after the backend PR is merged**, otherwise the public docs will describe fields that don't exist in production yet.
- Both fields are purely additive — no breaking changes for existing API consumers.

## Test plan

- [ ] Confirm the rendered docs site shows `description` on `LineItem` and `price_part_name` on `PricePartItem`.
- [ ] Confirm the JSON sample under "Get Proposal Line items" includes both fields.
- [ ] Verify the backend response actually returns these fields before merging.