### PR TITLE
docs(get-project): document owner and collaborators fields

### DIFF
--- a/source/includes/_projects.md
+++ b/source/includes/_projects.md
@@ -313,7 +313,13 @@ curl "https://api.arcsite.com/v1/projects/<ID>" \
     "phone": "122122-121"
   },
   "tags": ["tag1", "tag2"],
-  "archived": false
+  "archived": false,
+  "owner": "owner@arcsite.com",
+  "collaborators": [
+    {"email": "admin@arcsite.com", "role": "PROJECT_ADMIN"},
+    {"email": "dev@arcsite.com", "role": "PROJECT_COLLABORATOR"},
+    {"email": "viewer@arcsite.com", "role": "PROJECT_VIEWER"}
+  ]
 }
 ```
 
@@ -322,6 +328,27 @@ Returns project of your organization by project id,
 ### HTTP Request
 
 `GET https://api.arcsite.com/v1/projects/<id>`
+
+### Response Fields
+
+In addition to the core project fields, the response includes who can access the project:
+
+| Field         | Type                                | Description                                                              |
+| ------------- | ----------------------------------- | ------------------------------------------------------------------------ |
+| owner         | String                              | Email of the project owner (the creator). Always a single email.         |
+| collaborators | List[[Collaborator](#collaborator)] | Users with access to the project, excluding the owner.                   |
+
+<aside class='notice'>
+The owner is returned as a separate field and never appears in <code>collaborators</code>. If you also need the owner in your own view, render it alongside the collaborator list.
+</aside>
+
+<aside class='notice'>
+When a project is shared with a user group, the group's members are flattened into <code>collaborators</code> as individual entries, each carrying the group's role. The group name itself is not returned.
+</aside>
+
+<aside class='notice'>
+If a user has access through multiple paths (e.g., directly and via a group), they appear once with the highest-priority role, where <code>PROJECT_ADMIN</code> > <code>PROJECT_COLLABORATOR</code> > <code>PROJECT_VIEWER</code>. Inactive users are excluded.
+</aside>
 
 ## Search Projects
 


### PR DESCRIPTION
参考链接：[ARC-3319](https://arcsite.atlassian.net/browse/ARC-3319) · backend PR: https://github.com/Arctuition/cloudservice/pull/5215

## 背景（一句话）

`GET /v1/projects/<id>` 新增了 `owner` 和 `collaborators` 字段（ARC-3319），文档同步说明。

## 决策

- 用三条 `<aside class='notice'>` 显式写出客户最容易踩的三个边界：owner 单独字段、group 自动展开、多路径取最高 role + inactive 过滤 —— 这些行为客户从 schema 看不出来，必须文档兜底。
- Collaborator / Role 表沿用 [Add Project Collaborators](#add-project-collaborators) 里已有定义（\`#collaborator\`、\`#role\` 锚点），不重复。
- 只改 `Get Project` 段，**不动 Search Projects** —— 后端这版也没在 list 接口加这两个字段。

## 风险 · reviewer 看哪里（必填）

- **最可能藏 bug 的地方：** 三条 aside 的措辞与后端实现是否完全吻合（尤其"owner 同时在某个被分享 group 中也仍然不出现在 collaborators"这条隐性边界）。
- **请重点看：** \`source/includes/_projects.md\` 的 Response Fields 表 + 三条 aside；JSON 示例字段顺序是否合理。
- **我最没把握的一处：** 三条 aside 是否过多 —— 想保持"客户看一眼就知道边界"，但担心 Stripe 风格的简洁度被打破。如果觉得啰嗦可以合并成一条。
- **怎么验证的：** 本地 \`bundle exec middleman server\` 渲染过，三条 aside 都在 Get Project 段内正确显示；后端字段名 / role 字符串与 \`prj_privilege_svc.OpenAPIProjectCollaborators\` TypedDict 字段对照过。

- [ ] 这份 diff 由我担责。上面的「决策」和「风险」是我判断后写的，reviewer 追问我答得出。
